### PR TITLE
Enables Psychiatry on Toolbox

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -4623,7 +4623,7 @@
 "bKU" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on{dir = 4},/obj/machinery/light{dir = 8},/turf/open/floor/wood,/area/medical/psychiatry)
 "bKV" = (/obj/machinery/atmospherics/pipe/simple/supply/hidden,/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{dir = 4},/obj/structure/cable{icon_state = "2-4"},/turf/open/floor/wood,/area/medical/psychiatry)
 "bKW" = (/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{dir = 4},/obj/structure/cable{icon_state = "4-8"},/turf/open/floor/wood,/area/medical/psychiatry)
-"bKX" = (/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{dir = 4},/obj/machinery/door/airlock/medical{name = "Psychiatry"; req_access = "69"},/obj/structure/cable{icon_state = "4-8"},/turf/open/floor/wood,/area/medical/psychiatry)
+"bKX" = (/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{dir = 4},/obj/machinery/door/airlock/medical{name = "Psychiatry"; req_access = null; req_access_txt = "69"},/obj/structure/cable{icon_state = "4-8"},/turf/open/floor/wood,/area/medical/psychiatry)
 "bKY" = (/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{dir = 4},/obj/structure/cable{icon_state = "4-8"},/turf/open/floor/plasteel/white,/area/medical/medbay/central)
 "bKZ" = (/obj/structure/disposalpipe/junction/flip{dir = 2},/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,/obj/structure/cable{icon_state = "2-8"},/turf/open/floor/plasteel/white,/area/medical/medbay/central)
 "bLa" = (/obj/structure/disposalpipe/segment{dir = 9},/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{dir = 4},/obj/machinery/atmospherics/pipe/simple/supply/hidden,/turf/open/floor/plasteel/white,/area/medical/medbay/central)

--- a/code/modules/_toolbox/psychiatrist.dm
+++ b/code/modules/_toolbox/psychiatrist.dm
@@ -277,11 +277,13 @@
 	minimal_access = list(ACCESS_MEDICAL, ACCESS_PSYCHIATRIST)
 	position_after_type = /datum/job/virologist
 
+/* This check is stopping the job from being selectable even on Box
 /datum/job/psychiatrist/map_check() //making psychiatrist only available if mapped in.
 	for(var/obj/effect/landmark/start/sloc in GLOB.start_landmarks_list)
 		if(sloc.name != title)
 			return 1
 	return 0
+*/
 
 /area/medical/psychiatry
 	name = "Psychiatry Office"


### PR DESCRIPTION
This enables psychiatry on Toolbox. Currently the mapcheck code in psychiatry.dm is stopping psychiatrist role entirely round joins.

This comments out the code and corrects the req_access var for the psych door on Box Station. The other stations were okay.

Fixes #5 