### PR TITLE
Nerfs Perseus using ideas suggested by Killing Torcher and myself.

### DIFF
--- a/code/modules/_toolbox/perseus/equipment/clothing.dm
+++ b/code/modules/_toolbox/perseus/equipment/clothing.dm
@@ -13,7 +13,7 @@
 	icon = 'icons/oldschool/perseus.dmi'
 	alternate_worn_icon = 'icons/oldschool/perseus_worn.dmi'
 	flags_1 = NOSLIP_1
-	armor = list("melee" = 80, "bullet" = 60, "laser" = 50, "energy" = 25, "bomb" = 50, "bio" = 10, "rad" = 0)
+	armor = list("melee" = 25, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = 50, "bio" = 10, "rad" = 0)
 	var/obj/item/stun_knife/knife
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
@@ -95,7 +95,7 @@
 	item_state = "persarmour"
 	icon = 'icons/oldschool/perseus.dmi'
 	alternate_worn_icon = 'icons/oldschool/perseus_worn.dmi'
-	armor = list("melee" = 50, "bullet" = 15, "laser" = 50, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0)
+	armor = list("melee" = 30, "bullet" = 30, "laser" = 30, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0)
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
@@ -214,7 +214,7 @@
 	flags_inv = HIDEFACE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	flags_inv = 0
-	armor = list("melee" = 70, "bullet" = 55, "laser" = 45, "energy" = 10, "bomb" = 25, "bio" = 10, "rad" = 0)
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0)
 /*
 * Perseus Helmet
 */
@@ -228,7 +228,8 @@
 	flags_1 = THICKMATERIAL_1 | STOPSPRESSUREDMAGE_1
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEFACE | HIDEHAIR
-	armor = list("melee" = 70, "bullet" = 55, "laser" = 45, "energy" = 10, "bomb" = 25, "bio" = 10, "rad" = 0)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	armor = list("melee" = 35, "bullet" = 30, "laser" = 30, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0)
 
 /*
 * Perseus Winter Coat
@@ -307,6 +308,10 @@
 	var/authorized_lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	//origin_tech = "magnets=3"
 	//invis_view = SEE_INVISIBLE_MINIMUM
+
+/obj/item/clothing/glasses/perseus/emp_act(severity)
+	thermal_overload()
+	..()
 
 /obj/item/clothing/glasses/perseus/New()
 	SSobj.processing += src

--- a/code/modules/_toolbox/perseus/equipment/ep90.dm
+++ b/code/modules/_toolbox/perseus/equipment/ep90.dm
@@ -1,8 +1,8 @@
 var/const/EP_STUNTIME_SINGLE = 1 * 20
-var/const/EP_STUNTIME_AOE = 1 * 20
+var/const/EP_STUNTIME_AOE = 2 * 20
 
 var/const/IS_EP_SINGLE_STACKING = 1 * 20
-var/const/IS_EP_AOE_STACKING = 1 * 20
+var/const/IS_EP_AOE_STACKING = 2 * 20
 
 var/const/EP_MAX_SINGLE_STACK = 7 * 20
 var/const/EP_MAX_AOE_STACK = 7 * 20
@@ -182,7 +182,7 @@ var/const/EP_MAX_AOE_STACK = 7 * 20
 	name = "energy"
 	icon_state = "ep90shot"
 	icon = 'icons/oldschool/perseus.dmi'
-	hitsound = 'sound/weapons/taserhit.ogg'
+	hitsound = 'sound/effects/sparks1.ogg'
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	stun = EP_STUNTIME_SINGLE
 	knockdown = EP_STUNTIME_SINGLE
@@ -234,7 +234,7 @@ var/const/EP_MAX_AOE_STACK = 7 * 20
 	name = "energy"
 	icon_state = "ep90shot"
 	icon = 'icons/oldschool/perseus.dmi'
-	hitsound = 'sound/weapons/taserhit.ogg'
+	hitsound = 'sound/effects/sparks1.ogg'
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
 	stun = EP_STUNTIME_AOE
@@ -286,7 +286,7 @@ var/const/EP_MAX_AOE_STACK = 7 * 20
 /obj/item/ammo_casing/energy/ep90_single
 	select_name = "semi-automatic fire"
 	projectile_type = /obj/item/projectile/energy/ep90_single
-	e_cost = 20
+	e_cost = 40
 	fire_sound = 'sound/toolbox/ep90.ogg'
 
 /obj/item/ammo_casing/energy/ep90_single/newshot(var/emagged = 0)
@@ -297,7 +297,7 @@ var/const/EP_MAX_AOE_STACK = 7 * 20
 /obj/item/ammo_casing/energy/ep90_aoe
 	select_name = "area-of-effect fire"
 	projectile_type = /obj/item/projectile/energy/ep90_aoe
-	e_cost = 100
+	e_cost = 500
 	fire_sound = 'sound/toolbox/ep90.ogg'
 
 /obj/item/ammo_casing/energy/ep90_aoe/newshot(var/emagged = 0)
@@ -309,7 +309,7 @@ var/const/EP_MAX_AOE_STACK = 7 * 20
 /obj/item/ammo_casing/energy/ep90_burst_3
 	select_name = "3-round-burst"
 	projectile_type = /obj/item/projectile/energy/ep90_single
-	e_cost = 20
+	e_cost = 40
 	fire_sound = 'sound/toolbox/ep90.ogg'
 	burst = 3
 	burst_delay = 1.6
@@ -323,7 +323,7 @@ var/const/EP_MAX_AOE_STACK = 7 * 20
 /obj/item/ammo_casing/energy/ep90_burst_5
 	select_name = "5-round-burst"
 	projectile_type = /obj/item/projectile/energy/ep90_single
-	e_cost = 20
+	e_cost = 40
 	fire_sound = 'sound/toolbox/ep90.ogg'
 	burst = 5
 	burst_delay = 2.7

--- a/code/modules/_toolbox/perseus/equipment/other.dm
+++ b/code/modules/_toolbox/perseus/equipment/other.dm
@@ -200,7 +200,7 @@ removed sections which read.
 			..()
 			reagents.add_reagent("synaptizine", 5)
 			reagents.add_reagent("omnizine", 5)
-			reagents.add_reagent("stimulants", 5)
+			reagents.add_reagent("ephedrine", 5)
 
 /*
 * Stimpack Tank

--- a/code/modules/_toolbox/perseus/equipment/perseus_datum.dm
+++ b/code/modules/_toolbox/perseus/equipment/perseus_datum.dm
@@ -77,7 +77,7 @@
 	var/perc_identifier = "ERROR"
 	var/datum/mind/owner_mind = null
 	var/mob/living/last_mob = null
-	var/list/action_datums = list(/datum/action/padrenal = 10,/datum/action/pdoors = 0) //must be /datum/action. Added number is how many players are required to be playing for this to work. -falaskian
+	var/list/action_datums = list(/datum/action/pdoors = 0) //must be /datum/action. Added number is how many players are required to be playing for this to work. -falaskian
 	var/list/active_actions = list()
 	var/iscommander = 0
 	var/list/handled_client_images = list()
@@ -283,6 +283,7 @@
 		return 0
 
 	to_chat(H, "<span class='notice'>You feel a sudden surge of energy! Return to the Mycenae to recharge your [name].</span>")
+
 	H.SetStun(0)
 	H.SetKnockdown(0)
 	H.SetUnconscious(0)
@@ -292,7 +293,8 @@
 
 	H.reagents.add_reagent("synaptizine", 10)
 	H.reagents.add_reagent("omnizine", 10)
-	H.reagents.add_reagent("stimulants", 10)
+	H.reagents.add_reagent("ephedrine", 10)
+
 	cooldown = 1
 	UpdateButtonIcon()
 

--- a/code/modules/_toolbox/perseus/equipment/weapons.dm
+++ b/code/modules/_toolbox/perseus/equipment/weapons.dm
@@ -8,8 +8,7 @@
 */
 
 /obj/item/projectile/bullet/fiveseven
-	damage = 49
-	knockdown = 120
+	damage = 24
 
 /obj/item/ammo_casing/fiveseven
 	desc = "A 5.7x28mm casing"


### PR DESCRIPTION
**Changelog:**
- Removed perc adrenal.
- Doubled energy cost of EP-90 singleshot to 40 (from 20), capable of 25 singleshots (from 50).
- Increase AoE cost to 500 (from 100), fully charged cell can fire 2 AoE shots (from 10).
- Doubled AoE stuntime to two ticks (from one).
- Five-Seven now deals 24 damage per shot (from 49), and no longer stuns.
- Nerfed stimpack "stimulants" to "ephedrine" (No more 90% stun reduction).
- Perseus armor is now equal to current station security armor values (nerfed shoe armor too assuming it even does something).
- Fixed fire and acid immunity for Perseus helmet.
- Added blindness EMP act to Percvision goggles.
- Changed taser sound from EP90 energy bolts to spark sound.
