### PR TITLE
Adds Mindshield implants to CE,HOP,CMO and RD

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -100,3 +100,5 @@ Head of Personnel
 	head = /obj/item/clothing/head/hopcap
 	backpack_contents = list(/obj/item/storage/box/ids=1,\
 		/obj/item/melee/classic_baton/telescopic=1, /obj/item/device/modular_computer/tablet/preset/advanced = 1)
+
+    implants = list(/obj/item/implant/mindshield)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -101,4 +101,4 @@ Head of Personnel
 	backpack_contents = list(/obj/item/storage/box/ids=1,\
 		/obj/item/melee/classic_baton/telescopic=1, /obj/item/device/modular_computer/tablet/preset/advanced = 1)
 
-    implants = list(/obj/item/implant/mindshield)
+	implants = list(/obj/item/implant/mindshield)

--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -60,7 +60,8 @@ Chief Engineer
 	gloves = /obj/item/clothing/gloves/color/yellow
 	head = null
 	internals_slot = slot_s_store
-
+    
+	implants = list(/obj/item/implant/mindshield)
 
 /*
 Station Engineer

--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -46,6 +46,8 @@ Chief Medical Officer
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
+	
+	implants = list(/obj/item/implant/mindshield)
 
 /*
 Medical Doctor

--- a/code/modules/jobs/job_types/science.dm
+++ b/code/modules/jobs/job_types/science.dm
@@ -48,6 +48,8 @@ Research Director
 
 	backpack = /obj/item/storage/backpack/science
 	satchel = /obj/item/storage/backpack/satchel/tox
+	
+	implants = list(/obj/item/implant/mindshield)
 
 /datum/outfit/job/rd/rig
 	name = "Research Director (Hardsuit)"


### PR DESCRIPTION
[Changelogs]: #10 Added mindshield implants to all heads of staff: CE,HOP,CMO and RD


[why]: # As many of our rounds are with low population, so its very likely to have an acting Captain that manages to be a traitor (Or uses an Antag Token) and with Little to no sec to stop them the round usually ends in a murderboning spree and instantaneous win for the antagonist , with this change we prevent that from happening and makes heads more of an ally to sec aiding with the understaffing problema.